### PR TITLE
Add arrow function name highlighting

### DIFF
--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -669,7 +669,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-                                        <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
+					<string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -754,24 +754,24 @@
 					<key>name</key>
 					<string>keyword.operator.logical.pluto</string>
 				</dict>
-                                <dict>
-                                        <key>match</key>
-                                        <string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
-                                        <key>captures</key>
-                                        <dict>
-                                                <key>1</key>
-                                                <dict>
-                                                        <key>name</key>
-                                                        <string>entity.name.function.arrow.pluto</string>
-                                                </dict>
-                                        </dict>
-                                </dict>
-                                <dict>
-                                        <key>match</key>
-                                        <string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*(?:[({"']|\$["']|\[\[))</string>
-                                        <key>name</key>
-                                        <string>support.function.any-method.pluto</string>
-                                </dict>
+				<dict>
+					<key>match</key>
+					<string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.arrow.pluto</string>
+						</dict>
+					</dict>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*(?:[({"']|\$["']|\[\[))</string>
+					<key>name</key>
+					<string>support.function.any-method.pluto</string>
+				</dict>
 				<dict>
 					<key>match</key>
 					<string>(?&lt;=[^.]\.|:)\b([a-zA-Z_][a-zA-Z0-9_]*)</string>

--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -669,7 +669,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\??))?</string>
+                                        <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -754,12 +754,24 @@
 					<key>name</key>
 					<string>keyword.operator.logical.pluto</string>
 				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*(?:[({"']|\$["']|\[\[))</string>
-					<key>name</key>
-					<string>support.function.any-method.pluto</string>
-				</dict>
+                                <dict>
+                                        <key>match</key>
+                                        <string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
+                                        <key>captures</key>
+                                        <dict>
+                                                <key>1</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>entity.name.function.arrow.pluto</string>
+                                                </dict>
+                                        </dict>
+                                </dict>
+                                <dict>
+                                        <key>match</key>
+                                        <string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b(?=\s*(?:[({"']|\$["']|\[\[))</string>
+                                        <key>name</key>
+                                        <string>support.function.any-method.pluto</string>
+                                </dict>
 				<dict>
 					<key>match</key>
 					<string>(?&lt;=[^.]\.|:)\b([a-zA-Z_][a-zA-Z0-9_]*)</string>

--- a/test.js
+++ b/test.js
@@ -62,16 +62,15 @@ async function main()
     };
 
     checkClassification(
-        `local enums = {}`,
-        `-----            storage.modifier.pluto
+`local enums = {}`,
+`-----            storage.modifier.pluto
             -    keyword.operator.assignment.pluto
               -  punctuation.section.table.begin.pluto
                - punctuation.section.table.end.pluto
 `);
-
-    checkClassification(
-        `local a = || -> 1`,
-        `-----             storage.modifier.pluto
+checkClassification(
+`local a = || -> 1`,
+`-----             storage.modifier.pluto
       -           entity.name.function.arrow.pluto
         -         keyword.operator.assignment.pluto
           -       punctuation.section.group.begin.pluto

--- a/test.js
+++ b/test.js
@@ -62,11 +62,22 @@ async function main()
     };
 
     checkClassification(
-`local enums = {}`,
-`-----            storage.modifier.pluto
+        `local enums = {}`,
+        `-----            storage.modifier.pluto
             -    keyword.operator.assignment.pluto
               -  punctuation.section.table.begin.pluto
                - punctuation.section.table.end.pluto
+`);
+
+    checkClassification(
+        `local a = || -> 1`,
+        `-----             storage.modifier.pluto
+      -           entity.name.function.arrow.pluto
+        -         keyword.operator.assignment.pluto
+          -       punctuation.section.group.begin.pluto
+           -      punctuation.section.group.end.pluto
+             --   storage.type.function.arrow.pluto
+                - constant.numeric.integer.pluto
 `);
 
     if (!ok)


### PR DESCRIPTION
## Summary
- detect arrow function definitions and highlight function names
- exclude arrow functions from generic `local` declarations
- test classification for arrow function names
- fix expected spacing in arrow function classification test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858bd3950c8832599ad29998bef0813