### PR TITLE
Handle indentation for try-catch syntax

### DIFF
--- a/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
+++ b/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
@@ -7,9 +7,9 @@
 		<dict>
 			<!-- Keep in sync with language-config.json -->
 			<key>increaseIndentPattern</key>
-			<string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
+			<string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
 			<key>decreaseIndentPattern</key>
-			<string>(^\s*\$?\b(elsei|elseif|else|catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
+			<string>(^\s*\$?\b(elsei|elseif|else|catch|pluto_catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
 		</dict>
 	</dict>
 </plist>

--- a/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
+++ b/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
@@ -7,9 +7,9 @@
 		<dict>
 			<!-- Keep in sync with language-config.json -->
 			<key>increaseIndentPattern</key>
-                        <string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
-                        <key>decreaseIndentPattern</key>
-                        <string>(^\s*\$?\b(elsei|elseif|else|catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
-                </dict>
-        </dict>
+			<string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
+			<key>decreaseIndentPattern</key>
+			<string>(^\s*\$?\b(elsei|elseif|else|catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
+		</dict>
+	</dict>
 </plist>

--- a/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
+++ b/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
@@ -7,9 +7,9 @@
 		<dict>
 			<!-- Keep in sync with language-config.json -->
 			<key>increaseIndentPattern</key>
-			<string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
-			<key>decreaseIndentPattern</key>
-			<string>(^\s*\$?\b(elsei|elseif|else|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
-		</dict>
-	</dict>
+                        <string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
+                        <key>decreaseIndentPattern</key>
+                        <string>(^\s*\$?\b(elsei|elseif|else|catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
+                </dict>
+        </dict>
 </plist>

--- a/language-config.json
+++ b/language-config.json
@@ -5,7 +5,7 @@
 	},
 	// Keep in sync with Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
 	"indentationRules": {
-		"increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
-		"decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
-	}
+                "increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
+                "decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
+        }
 }

--- a/language-config.json
+++ b/language-config.json
@@ -5,7 +5,7 @@
 	},
 	// Keep in sync with Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
 	"indentationRules": {
-                "increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
-                "decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
-        }
+		"increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
+		"decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
+	}
 }

--- a/language-config.json
+++ b/language-config.json
@@ -5,7 +5,7 @@
 	},
 	// Keep in sync with Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
 	"indentationRules": {
-		"increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
-		"decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
+		"increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
+		"decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|pluto_catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -102,8 +102,11 @@ async function main()
     checkIndentation("if cond then", true, false);
     checkIndentation("else", true, true);
     checkIndentation("try", true, false);
+    checkIndentation("pluto_try", true, false);
     checkIndentation("catch e then", true, true);
     checkIndentation("catch e do", true, true);
+    checkIndentation("pluto_catch e then", true, true);
+    checkIndentation("pluto_catch e do", true, true);
     checkIndentation("end", false, true);
     checkIndentation("until finished", false, true);
     checkIndentation("values = {", true, false);

--- a/test.js
+++ b/test.js
@@ -101,6 +101,9 @@ async function main()
     checkIndentation("function foo()", true, false);
     checkIndentation("if cond then", true, false);
     checkIndentation("else", true, true);
+    checkIndentation("try", true, false);
+    checkIndentation("catch e then", true, true);
+    checkIndentation("catch e do", true, true);
     checkIndentation("end", false, true);
     checkIndentation("until finished", false, true);
     checkIndentation("values = {", true, false);


### PR DESCRIPTION
## Summary
- test indentation behaviour for `try` and `catch` blocks
- support `try ... catch ... then/do` in indentation regexes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925528dd388325abc35d93ee751f42