### PR TITLE
Support complex table & function hints

### DIFF
--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -51,8 +51,8 @@
 						</dict>
 					</dict>
 					<key>end</key>
-                                       <string>(\))(?:(:)\s+(void|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|\{[^}]*\})\??))?(\s*&lt;nodiscard&gt;)?</string>
-                                       <key>endCaptures</key>
+					<string>(\))(?:(:)\s+(void|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|\{[^}]*\})\??))?(\s*&lt;nodiscard&gt;)?</string>
+					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
@@ -101,25 +101,25 @@
 							<key>name</key>
 							<string>punctuation.separator.comma.pluto</string>
 						</dict>
-                                                <dict>
-                                                        <key>match</key>
-                                                        <string>\.\.\.</string>
-                                                        <key>name</key>
-                                                        <string>constant.language.pluto</string>
-                                                </dict>
-                                               <dict>
-                                                        <key>include</key>
-                                                        <string>#function_type</string>
-                                               </dict>
-                                               <dict>
-                                                        <key>include</key>
-                                                        <string>#table_type</string>
-                                               </dict>
-                                               <dict>
-                                                        <key>match</key>
-                                                        <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-                                                        <key>captures</key>
-                                                        <dict>
+						<dict>
+							<key>match</key>
+							<string>\.\.\.</string>
+							<key>name</key>
+							<string>constant.language.pluto</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#function_type</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#table_type</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+							<key>captures</key>
+							<dict>
 								<key>1</key>
 								<dict>
 									<key>name</key>
@@ -553,33 +553,33 @@
 					</dict>
 					<key>patterns</key>
 					<array>
-                                                <dict>
-                                                        <key>begin</key>
-                                                        <string>\b(public|private|protected)\b</string>
-                                                        <key>beginCaptures</key>
-                                                        <dict>
-                                                                <key>1</key>
-                                                                <dict>
-                                                                        <key>name</key>
-                                                                        <string>storage.modifier.access.pluto</string>
-                                                                </dict>
-                                                        </dict>
-                                                        <key>end</key>
-                                                        <string>\w+</string>
-                                                </dict>
-                                               <dict>
-                                                        <key>include</key>
-                                                        <string>#function_type</string>
-                                               </dict>
-                                               <dict>
-                                                        <key>include</key>
-                                                        <string>#table_type</string>
-                                               </dict>
-                                               <dict>
-                                                        <key>match</key>
-                                                        <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-                                                        <key>captures</key>
-                                                        <dict>
+						<dict>
+							<key>begin</key>
+							<string>\b(public|private|protected)\b</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.access.pluto</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>\w+</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#function_type</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#table_type</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+							<key>captures</key>
+							<dict>
 								<key>1</key>
 								<dict>
 									<key>name</key>
@@ -683,83 +683,83 @@
 					<key>name</key>
 					<string>keyword.control.pluto</string>
 				</dict>
-                               <dict>
-                                   <key>begin</key>
-                                   <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)\s*(:)\s*(\{)</string>
-                                   <key>beginCaptures</key>
-                                   <dict>
-                                           <key>1</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>storage.modifier.pluto</string>
-                                           </dict>
-                                           <key>2</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
-                                           </dict>
-                                           <key>3</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>punctuation.separator.colon.pluto</string>
-                                           </dict>
-                                           <key>4</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>punctuation.section.table.begin.pluto</string>
-                                           </dict>
-                                   </dict>
-                                   <key>end</key>
-                                   <string>\}</string>
-                                   <key>endCaptures</key>
-                                   <dict>
-                                           <key>0</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>punctuation.section.table.end.pluto</string>
-                                           </dict>
-                                   </dict>
-                                   <key>name</key>
-                                   <string>meta.typehint.table.pluto</string>
-                                   <key>patterns</key>
-                                   <array>
-                                           <dict>
-                                                   <key>include</key>
-                                                   <string>#table_type_body</string>
-                                           </dict>
-                                   </array>
-                           </dict>
-                           <dict>
-                                   <key>include</key>
-                                   <string>#function_type</string>
-                           </dict>
-                           <dict>
-                                   <key>match</key>
-                                   <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(?!function\s*\()(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
-                                   <key>captures</key>
-                                   <dict>
-                                           <key>1</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>storage.modifier.pluto</string>
-                                           </dict>
-                                           <key>2</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
-                                           </dict>
-                                           <key>3</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>punctuation.separator.colon.pluto</string>
-                                           </dict>
-                                           <key>4</key>
-                                           <dict>
-                                                   <key>name</key>
-                                                   <string>storage.type.primitive.pluto</string>
-                                           </dict>
-                                   </dict>
-                           </dict>
+				<dict>
+					<key>begin</key>
+					<string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)\s*(:)\s*(\{)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.pluto</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.colon.pluto</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.table.begin.pluto</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.table.end.pluto</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.typehint.table.pluto</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#table_type_body</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(?!function\s*\()(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.pluto</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.colon.pluto</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.primitive.pluto</string>
+						</dict>
+					</dict>
+				</dict>
 				<dict>
 					<key>match</key>
 					<string>\b(?&lt;![.\:])(local|global|export|pluto_export)\b</string>
@@ -1249,229 +1249,229 @@
 					</array>
 				</dict>
 			</array>
-                </dict>
-                <key>table_type</key>
-                <dict>
-                        <key>begin</key>
-                        <string>(:)\s*(\{)</string>
-                        <key>beginCaptures</key>
-                        <dict>
-                                <key>1</key>
-                                <dict>
-                                        <key>name</key>
-                                        <string>punctuation.separator.colon.pluto</string>
-                                </dict>
-                                <key>2</key>
-                                <dict>
-                                        <key>name</key>
-                                        <string>punctuation.section.table.begin.pluto</string>
-                                </dict>
-                        </dict>
-                        <key>end</key>
-                        <string>\}</string>
-                        <key>endCaptures</key>
-                        <dict>
-                                <key>0</key>
-                                <dict>
-                                        <key>name</key>
-                                        <string>punctuation.section.table.end.pluto</string>
-                                </dict>
-                        </dict>
-                        <key>name</key>
-                        <string>meta.typehint.table.pluto</string>
-                        <key>patterns</key>
-                        <array>
-                                <dict>
-                                        <key>include</key>
-                                        <string>#table_type_body</string>
-                                </dict>
-                        </array>
-                </dict>
-                <key>table_type_body</key>
-                <dict>
-                        <key>patterns</key>
-                        <array>
-                                <dict>
-                                        <key>match</key>
-                                        <string>[a-zA-Z_][a-zA-Z0-9_]*</string>
-                                        <key>name</key>
-                                        <string>variable.other.field.pluto</string>
-                                </dict>
-                                <dict>
-                                        <key>include</key>
-                                        <string>#function_type</string>
-                                </dict>
-                                <dict>
-                                        <key>include</key>
-                                        <string>#table_type</string>
-                                </dict>
-                                <dict>
-                                        <key>match</key>
-                                        <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-                                        <key>captures</key>
-                                        <dict>
-                                                <key>1</key>
-                                                <dict>
-                                                        <key>name</key>
-                                                        <string>punctuation.separator.colon.pluto</string>
-                                                </dict>
-                                                <key>2</key>
-                                                <dict>
-                                                        <key>name</key>
-                                                        <string>storage.type.primitive.pluto</string>
-                                                </dict>
-                                        </dict>
-                                        <key>name</key>
-                                        <string>meta.typehint.pluto</string>
-                                </dict>
-                                <dict>
-                                        <key>match</key>
-                                        <string>;</string>
-                                        <key>name</key>
-                                        <string>punctuation.terminator.semicolon.pluto</string>
-                                </dict>
-                               <dict>
-                                       <key>match</key>
-                                       <string>,</string>
-                                       <key>name</key>
-                                       <string>punctuation.separator.comma.pluto</string>
-                               </dict>
-                       </array>
-               </dict>
-               <key>function_type</key>
-<dict>
-<key>begin</key>
-<string>(:)\s*(function)\s*(?=\()</string>
-<key>beginCaptures</key>
-<dict>
-<key>1</key>
-<dict>
-<key>name</key>
-<string>punctuation.separator.colon.pluto</string>
-</dict>
-<key>2</key>
-<dict>
-<key>name</key>
-<string>storage.type.function.pluto</string>
-</dict>
-</dict>
-<key>end</key>
-<string>(?=[,)=\}\]\|$])</string>
-<key>name</key>
-<string>meta.typehint.function.pluto</string>
-<key>patterns</key>
-<array>
-<dict>
-<key>begin</key>
-<string>\(</string>
-<key>beginCaptures</key>
-<dict>
-<key>0</key>
-<dict>
-<key>name</key>
-<string>punctuation.section.group.begin.pluto</string>
-</dict>
-</dict>
-<key>end</key>
-<string>\)</string>
-<key>endCaptures</key>
-<dict>
-<key>0</key>
-<dict>
-<key>name</key>
-<string>punctuation.section.group.end.pluto</string>
-</dict>
-</dict>
-<key>patterns</key>
-<array>
-<dict>
-<key>include</key>
-<string>#function_type_params</string>
-</dict>
-</array>
-</dict>
-<dict>
-<key>include</key>
-<string>#function_type</string>
-</dict>
-<dict>
-<key>include</key>
-<string>#table_type</string>
-</dict>
-<dict>
-<key>match</key>
-<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-<key>captures</key>
-<dict>
-<key>1</key>
-<dict>
-<key>name</key>
-<string>punctuation.separator.colon.pluto</string>
-</dict>
-<key>2</key>
-<dict>
-<key>name</key>
-<string>storage.type.primitive.pluto</string>
-</dict>
-</dict>
-<key>name</key>
-<string>meta.typehint.pluto</string>
-</dict>
-</array>
-</dict>
-<key>function_type_params</key>
-<dict>
-<key>patterns</key>
-<array>
-<dict>
-<key>match</key>
-<string>[a-zA-Z_][a-zA-Z0-9_]*</string>
-<key>name</key>
-<string>variable.parameter.function.pluto</string>
-</dict>
-<dict>
-<key>match</key>
-<string>,</string>
-<key>name</key>
-<string>punctuation.separator.comma.pluto</string>
-</dict>
-<dict>
-<key>match</key>
-<string>\.\.\.</string>
-<key>name</key>
-<string>constant.language.pluto</string>
-</dict>
-<dict>
-<key>include</key>
-<string>#function_type</string>
-</dict>
-<dict>
-<key>include</key>
-<string>#table_type</string>
-</dict>
-<dict>
-<key>match</key>
-<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-<key>captures</key>
-<dict>
-<key>1</key>
-<dict>
-<key>name</key>
-<string>punctuation.separator.colon.pluto</string>
-</dict>
-<key>2</key>
-<dict>
-<key>name</key>
-<string>storage.type.primitive.pluto</string>
-</dict>
-</dict>
-<key>name</key>
-<string>meta.typehint.pluto</string>
-</dict>
-</array>
-</dict>
-<key>string_inner</key>
-<dict>
+		</dict>
+		<key>table_type</key>
+		<dict>
+			<key>begin</key>
+			<string>(:)\s*(\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.colon.pluto</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.table.begin.pluto</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\}</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.table.end.pluto</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.typehint.table.pluto</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#table_type_body</string>
+				</dict>
+			</array>
+		</dict>
+		<key>table_type_body</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>[a-zA-Z_][a-zA-Z0-9_]*</string>
+					<key>name</key>
+					<string>variable.other.field.pluto</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_type</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#table_type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.colon.pluto</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.primitive.pluto</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.typehint.pluto</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>;</string>
+					<key>name</key>
+					<string>punctuation.terminator.semicolon.pluto</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>,</string>
+					<key>name</key>
+					<string>punctuation.separator.comma.pluto</string>
+				</dict>
+			</array>
+		</dict>
+		<key>function_type</key>
+		<dict>
+			<key>begin</key>
+			<string>(:)\s*(function)\s*(?=\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.colon.pluto</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.function.pluto</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?=[,)=\}\]\|$])</string>
+			<key>name</key>
+			<string>meta.typehint.function.pluto</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\(</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.group.begin.pluto</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.group.end.pluto</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#function_type_params</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_type</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#table_type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.colon.pluto</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.primitive.pluto</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.typehint.pluto</string>
+				</dict>
+			</array>
+		</dict>
+		<key>function_type_params</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>[a-zA-Z_][a-zA-Z0-9_]*</string>
+					<key>name</key>
+					<string>variable.parameter.function.pluto</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>,</string>
+					<key>name</key>
+					<string>punctuation.separator.comma.pluto</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\.\.\.</string>
+					<key>name</key>
+					<string>constant.language.pluto</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#function_type</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#table_type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.colon.pluto</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.primitive.pluto</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.typehint.pluto</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string_inner</key>
+		<dict>
 			<key>patterns</key>
 			<array>
 				<!-- escaped chars -->

--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -109,9 +109,13 @@
                                                 </dict>
                                                <dict>
                                                         <key>include</key>
+                                                        <string>#function_type</string>
+                                               </dict>
+                                               <dict>
+                                                        <key>include</key>
                                                         <string>#table_type</string>
-                                                </dict>
-                                                <dict>
+                                               </dict>
+                                               <dict>
                                                         <key>match</key>
                                                         <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
                                                         <key>captures</key>
@@ -565,9 +569,13 @@
                                                 </dict>
                                                <dict>
                                                         <key>include</key>
+                                                        <string>#function_type</string>
+                                               </dict>
+                                               <dict>
+                                                        <key>include</key>
                                                         <string>#table_type</string>
-                                                </dict>
-                                                <dict>
+                                               </dict>
+                                               <dict>
                                                         <key>match</key>
                                                         <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
                                                         <key>captures</key>
@@ -722,8 +730,12 @@
                                    </array>
                            </dict>
                            <dict>
+                                   <key>include</key>
+                                   <string>#function_type</string>
+                           </dict>
+                           <dict>
                                    <key>match</key>
-                                   <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
+                                   <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(?!function\s*\()(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
                                    <key>captures</key>
                                    <dict>
                                            <key>1</key>
@@ -1287,6 +1299,10 @@
                                 </dict>
                                 <dict>
                                         <key>include</key>
+                                        <string>#function_type</string>
+                                </dict>
+                                <dict>
+                                        <key>include</key>
                                         <string>#table_type</string>
                                 </dict>
                                 <dict>
@@ -1312,12 +1328,144 @@
                                         <key>match</key>
                                         <string>;</string>
                                         <key>name</key>
-                                        <string>punctuation.terminator.semicolon.pluto</string>
-                                </dict>
-                        </array>
-                </dict>
-                <key>string_inner</key>
-                <dict>
+<string>punctuation.terminator.semicolon.pluto</string>
+</dict>
+</array>
+</dict>
+<key>function_type</key>
+<dict>
+<key>begin</key>
+<string>(:)\s*(function)\s*(?=\()</string>
+<key>beginCaptures</key>
+<dict>
+<key>1</key>
+<dict>
+<key>name</key>
+<string>punctuation.separator.colon.pluto</string>
+</dict>
+<key>2</key>
+<dict>
+<key>name</key>
+<string>storage.type.function.pluto</string>
+</dict>
+</dict>
+<key>end</key>
+<string>(?=[,)=\}\]\|$])</string>
+<key>name</key>
+<string>meta.typehint.function.pluto</string>
+<key>patterns</key>
+<array>
+<dict>
+<key>begin</key>
+<string>\(</string>
+<key>beginCaptures</key>
+<dict>
+<key>0</key>
+<dict>
+<key>name</key>
+<string>punctuation.section.group.begin.pluto</string>
+</dict>
+</dict>
+<key>end</key>
+<string>\)</string>
+<key>endCaptures</key>
+<dict>
+<key>0</key>
+<dict>
+<key>name</key>
+<string>punctuation.section.group.end.pluto</string>
+</dict>
+</dict>
+<key>patterns</key>
+<array>
+<dict>
+<key>include</key>
+<string>#function_type_params</string>
+</dict>
+</array>
+</dict>
+<dict>
+<key>include</key>
+<string>#function_type</string>
+</dict>
+<dict>
+<key>include</key>
+<string>#table_type</string>
+</dict>
+<dict>
+<key>match</key>
+<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+<key>captures</key>
+<dict>
+<key>1</key>
+<dict>
+<key>name</key>
+<string>punctuation.separator.colon.pluto</string>
+</dict>
+<key>2</key>
+<dict>
+<key>name</key>
+<string>storage.type.primitive.pluto</string>
+</dict>
+</dict>
+<key>name</key>
+<string>meta.typehint.pluto</string>
+</dict>
+</array>
+</dict>
+<key>function_type_params</key>
+<dict>
+<key>patterns</key>
+<array>
+<dict>
+<key>match</key>
+<string>[a-zA-Z_][a-zA-Z0-9_]*</string>
+<key>name</key>
+<string>variable.parameter.function.pluto</string>
+</dict>
+<dict>
+<key>match</key>
+<string>,</string>
+<key>name</key>
+<string>punctuation.separator.comma.pluto</string>
+</dict>
+<dict>
+<key>match</key>
+<string>\.\.\.</string>
+<key>name</key>
+<string>constant.language.pluto</string>
+</dict>
+<dict>
+<key>include</key>
+<string>#function_type</string>
+</dict>
+<dict>
+<key>include</key>
+<string>#table_type</string>
+</dict>
+<dict>
+<key>match</key>
+<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+<key>captures</key>
+<dict>
+<key>1</key>
+<dict>
+<key>name</key>
+<string>punctuation.separator.colon.pluto</string>
+</dict>
+<key>2</key>
+<dict>
+<key>name</key>
+<string>storage.type.primitive.pluto</string>
+</dict>
+</dict>
+<key>name</key>
+<string>meta.typehint.pluto</string>
+</dict>
+</array>
+</dict>
+<key>string_inner</key>
+<dict>
 			<key>patterns</key>
 			<array>
 				<!-- escaped chars -->

--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -51,8 +51,8 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\))(?:(:)\s+(void|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(\s*&lt;nodiscard&gt;)?</string>
-					<key>endCaptures</key>
+                                       <string>(\))(?:(:)\s+(void|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|\{[^}]*\})\??))?(\s*&lt;nodiscard&gt;)?</string>
+                                       <key>endCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
@@ -101,17 +101,21 @@
 							<key>name</key>
 							<string>punctuation.separator.comma.pluto</string>
 						</dict>
-						<dict>
-							<key>match</key>
-							<string>\.\.\.</string>
-							<key>name</key>
-							<string>constant.language.pluto</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-							<key>captures</key>
-							<dict>
+                                                <dict>
+                                                        <key>match</key>
+                                                        <string>\.\.\.</string>
+                                                        <key>name</key>
+                                                        <string>constant.language.pluto</string>
+                                                </dict>
+                                               <dict>
+                                                        <key>include</key>
+                                                        <string>#table_type</string>
+                                                </dict>
+                                                <dict>
+                                                        <key>match</key>
+                                                        <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+                                                        <key>captures</key>
+                                                        <dict>
 								<key>1</key>
 								<dict>
 									<key>name</key>
@@ -545,25 +549,29 @@
 					</dict>
 					<key>patterns</key>
 					<array>
-						<dict>
-							<key>begin</key>
-							<string>\b(public|private|protected)\b</string>
-							<key>beginCaptures</key>
-							<dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>storage.modifier.access.pluto</string>
-								</dict>
-							</dict>
-							<key>end</key>
-							<string>\w+</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
-							<key>captures</key>
-							<dict>
+                                                <dict>
+                                                        <key>begin</key>
+                                                        <string>\b(public|private|protected)\b</string>
+                                                        <key>beginCaptures</key>
+                                                        <dict>
+                                                                <key>1</key>
+                                                                <dict>
+                                                                        <key>name</key>
+                                                                        <string>storage.modifier.access.pluto</string>
+                                                                </dict>
+                                                        </dict>
+                                                        <key>end</key>
+                                                        <string>\w+</string>
+                                                </dict>
+                                               <dict>
+                                                        <key>include</key>
+                                                        <string>#table_type</string>
+                                                </dict>
+                                                <dict>
+                                                        <key>match</key>
+                                                        <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+                                                        <key>captures</key>
+                                                        <dict>
 								<key>1</key>
 								<dict>
 									<key>name</key>
@@ -667,33 +675,79 @@
 					<key>name</key>
 					<string>keyword.control.pluto</string>
 				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.pluto</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.colon.pluto</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>storage.type.primitive.pluto</string>
-						</dict>
-					</dict>
-				</dict>
+                               <dict>
+                                   <key>begin</key>
+                                   <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)\s*(:)\s*(\{)</string>
+                                   <key>beginCaptures</key>
+                                   <dict>
+                                           <key>1</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>storage.modifier.pluto</string>
+                                           </dict>
+                                           <key>2</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
+                                           </dict>
+                                           <key>3</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>punctuation.separator.colon.pluto</string>
+                                           </dict>
+                                           <key>4</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>punctuation.section.table.begin.pluto</string>
+                                           </dict>
+                                   </dict>
+                                   <key>end</key>
+                                   <string>\}</string>
+                                   <key>endCaptures</key>
+                                   <dict>
+                                           <key>0</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>punctuation.section.table.end.pluto</string>
+                                           </dict>
+                                   </dict>
+                                   <key>name</key>
+                                   <string>meta.typehint.table.pluto</string>
+                                   <key>patterns</key>
+                                   <array>
+                                           <dict>
+                                                   <key>include</key>
+                                                   <string>#table_type_body</string>
+                                           </dict>
+                                   </array>
+                           </dict>
+                           <dict>
+                                   <key>match</key>
+                                   <string>\b(?&lt;!\.)(local|global)\s+(?!class)(?!pluto_class)(?!function)(?:(and|break|do|else|elseif|end|false|for|function|goto|if|in|local|nil|not|or|repeat|pluto_use|pluto_switch|pluto_continue|pluto_enum|pluto_new|pluto_class|pluto_export|pluto_try|pluto_catch|switch|continue|enum|new|class|export|try|catch|return|then|true|until|while)\b|\w+)(?:\s*(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??))?(?!\s*=\s*\|[a-zA-Z0-9_,\s]*\|\s*-&gt;)</string>
+                                   <key>captures</key>
+                                   <dict>
+                                           <key>1</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>storage.modifier.pluto</string>
+                                           </dict>
+                                           <key>2</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>invalid.name.reserved.not-narrow.not-overridable.not-optional.not-special.pluto</string>
+                                           </dict>
+                                           <key>3</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>punctuation.separator.colon.pluto</string>
+                                           </dict>
+                                           <key>4</key>
+                                           <dict>
+                                                   <key>name</key>
+                                                   <string>storage.type.primitive.pluto</string>
+                                           </dict>
+                                   </dict>
+                           </dict>
 				<dict>
 					<key>match</key>
 					<string>\b(?&lt;![.\:])(local|global|export|pluto_export)\b</string>
@@ -1183,9 +1237,87 @@
 					</array>
 				</dict>
 			</array>
-		</dict>
-		<key>string_inner</key>
-		<dict>
+                </dict>
+                <key>table_type</key>
+                <dict>
+                        <key>begin</key>
+                        <string>(:)\s*(\{)</string>
+                        <key>beginCaptures</key>
+                        <dict>
+                                <key>1</key>
+                                <dict>
+                                        <key>name</key>
+                                        <string>punctuation.separator.colon.pluto</string>
+                                </dict>
+                                <key>2</key>
+                                <dict>
+                                        <key>name</key>
+                                        <string>punctuation.section.table.begin.pluto</string>
+                                </dict>
+                        </dict>
+                        <key>end</key>
+                        <string>\}</string>
+                        <key>endCaptures</key>
+                        <dict>
+                                <key>0</key>
+                                <dict>
+                                        <key>name</key>
+                                        <string>punctuation.section.table.end.pluto</string>
+                                </dict>
+                        </dict>
+                        <key>name</key>
+                        <string>meta.typehint.table.pluto</string>
+                        <key>patterns</key>
+                        <array>
+                                <dict>
+                                        <key>include</key>
+                                        <string>#table_type_body</string>
+                                </dict>
+                        </array>
+                </dict>
+                <key>table_type_body</key>
+                <dict>
+                        <key>patterns</key>
+                        <array>
+                                <dict>
+                                        <key>match</key>
+                                        <string>[a-zA-Z_][a-zA-Z0-9_]*</string>
+                                        <key>name</key>
+                                        <string>variable.other.field.pluto</string>
+                                </dict>
+                                <dict>
+                                        <key>include</key>
+                                        <string>#table_type</string>
+                                </dict>
+                                <dict>
+                                        <key>match</key>
+                                        <string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil)\??)</string>
+                                        <key>captures</key>
+                                        <dict>
+                                                <key>1</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>punctuation.separator.colon.pluto</string>
+                                                </dict>
+                                                <key>2</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>storage.type.primitive.pluto</string>
+                                                </dict>
+                                        </dict>
+                                        <key>name</key>
+                                        <string>meta.typehint.pluto</string>
+                                </dict>
+                                <dict>
+                                        <key>match</key>
+                                        <string>;</string>
+                                        <key>name</key>
+                                        <string>punctuation.terminator.semicolon.pluto</string>
+                                </dict>
+                        </array>
+                </dict>
+                <key>string_inner</key>
+                <dict>
 			<key>patterns</key>
 			<array>
 				<!-- escaped chars -->

--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -1328,11 +1328,17 @@
                                         <key>match</key>
                                         <string>;</string>
                                         <key>name</key>
-<string>punctuation.terminator.semicolon.pluto</string>
-</dict>
-</array>
-</dict>
-<key>function_type</key>
+                                        <string>punctuation.terminator.semicolon.pluto</string>
+                                </dict>
+                               <dict>
+                                       <key>match</key>
+                                       <string>,</string>
+                                       <key>name</key>
+                                       <string>punctuation.separator.comma.pluto</string>
+                               </dict>
+                       </array>
+               </dict>
+               <key>function_type</key>
 <dict>
 <key>begin</key>
 <string>(:)\s*(function)\s*(?=\()</string>

--- a/test.js
+++ b/test.js
@@ -82,6 +82,51 @@ async function main()
         `                - constant.numeric.integer.pluto`
     );
 
+    checkClassification(
+        `local p: { x: number } = { x = 1 }`,
+        `-----                              storage.modifier.pluto`,
+        `     --                            meta.typehint.table.pluto`,
+        `       -                           punctuation.separator.colon.pluto`,
+        `        -                          meta.typehint.table.pluto`,
+        `         -                         punctuation.section.table.begin.pluto`,
+        `          -                        meta.typehint.table.pluto`,
+        `           -                       variable.other.field.pluto`,
+        `            -                      punctuation.separator.colon.pluto`,
+        `             -                     meta.typehint.pluto`,
+        `              ------               storage.type.primitive.pluto`,
+        `                    -              meta.typehint.table.pluto`,
+        `                     -             punctuation.section.table.end.pluto`,
+        `                       -           keyword.operator.assignment.pluto`,
+        `                         -         punctuation.section.table.begin.pluto`,
+        `                          ---      meta.table.pluto`,
+        `                             -     keyword.operator.assignment.pluto`,
+        `                              -    meta.table.pluto`,
+        `                               -   constant.numeric.integer.pluto`,
+        `                                -  meta.table.pluto`,
+        `                                 - punctuation.section.table.end.pluto`
+    );
+
+    checkClassification(
+        `local function f(cb: { a: string })`,
+        `-----                               storage.modifier.pluto`,
+        `      --------                      storage.type.function.pluto`,
+        `              -                     meta.function.pluto`,
+        `               -                    entity.name.function.pluto`,
+        `                -                   punctuation.section.group.begin.pluto`,
+        `                 --                 variable.parameter.function.pluto`,
+        `                   -                punctuation.separator.colon.pluto`,
+        `                    -               meta.typehint.table.pluto`,
+        `                     -              punctuation.section.table.begin.pluto`,
+        `                      -             meta.typehint.table.pluto`,
+        `                       -            variable.other.field.pluto`,
+        `                        -           punctuation.separator.colon.pluto`,
+        `                         -          meta.typehint.pluto`,
+        `                          ------    storage.type.primitive.pluto`,
+        `                                -   meta.typehint.table.pluto`,
+        `                                 -  punctuation.section.table.end.pluto`,
+        `                                  - punctuation.section.group.end.pluto`
+    );
+
     const langConfig = JSON.parse(
         fs.readFileSync(path.join(__dirname, "language-config.json"), "utf8").replace(/\/\/.*$/gm, "")
     );

--- a/test.js
+++ b/test.js
@@ -127,6 +127,25 @@ async function main()
         `                                  - punctuation.section.group.end.pluto`
     );
 
+    checkClassification(
+        `local f: function(a: string): int = tonumber`,
+        `-----                                        storage.modifier.pluto`,
+        `       -                                     punctuation.separator.colon.pluto`,
+        `        -                                    meta.typehint.function.pluto`,
+        `         --------                            storage.type.function.pluto`,
+        `                 -                           punctuation.section.group.begin.pluto`,
+        `                  -                          variable.parameter.function.pluto`,
+        `                   -                         punctuation.separator.colon.pluto`,
+        `                    -                        meta.typehint.pluto`,
+        `                     ------                  storage.type.primitive.pluto`,
+        `                           -                 punctuation.section.group.end.pluto`,
+        `                            -                punctuation.separator.colon.pluto`,
+        `                             -               meta.typehint.pluto`,
+        `                              ---            storage.type.primitive.pluto`,
+        `                                 -           meta.typehint.function.pluto`,
+        `                                  -          keyword.operator.assignment.pluto`
+    );
+
     const langConfig = JSON.parse(
         fs.readFileSync(path.join(__dirname, "language-config.json"), "utf8").replace(/\/\/.*$/gm, "")
     );

--- a/test.js
+++ b/test.js
@@ -59,7 +59,8 @@ async function main()
         const actual = createClassificationString(code);
         if (actual != expected)
         {
-            console.log(`Mismatch for ${code}`);
+            console.log(code + " MISMATCH");
+            console.log(actual);
             ok = false;
         }
     };
@@ -83,62 +84,47 @@ async function main()
     );
 
     checkClassification(
-        `local p: { x: number } = { x = 1 }`,
-        `-----                              storage.modifier.pluto`,
-        `     --                            meta.typehint.table.pluto`,
-        `       -                           punctuation.separator.colon.pluto`,
-        `        -                          meta.typehint.table.pluto`,
-        `         -                         punctuation.section.table.begin.pluto`,
-        `          -                        meta.typehint.table.pluto`,
-        `           -                       variable.other.field.pluto`,
-        `            -                      punctuation.separator.colon.pluto`,
-        `             -                     meta.typehint.pluto`,
-        `              ------               storage.type.primitive.pluto`,
-        `                    -              meta.typehint.table.pluto`,
-        `                     -             punctuation.section.table.end.pluto`,
-        `                       -           keyword.operator.assignment.pluto`,
-        `                         -         punctuation.section.table.begin.pluto`,
-        `                          ---      meta.table.pluto`,
-        `                             -     keyword.operator.assignment.pluto`,
-        `                              -    meta.table.pluto`,
-        `                               -   constant.numeric.integer.pluto`,
-        `                                -  meta.table.pluto`,
-        `                                 - punctuation.section.table.end.pluto`
+        `local p: { x: number; y: number }`,
+        `-----                             storage.modifier.pluto`,
+        `     --                           meta.typehint.table.pluto`,
+        `       -                          punctuation.separator.colon.pluto`,
+        `        -                         meta.typehint.table.pluto`,
+        `         -                        punctuation.section.table.begin.pluto`,
+        `          -                       meta.typehint.table.pluto`,
+        `           -                      variable.other.field.pluto`,
+        `            -                     punctuation.separator.colon.pluto`,
+        `             -                    meta.typehint.pluto`,
+        `              ------              storage.type.primitive.pluto`,
+        `                    -             punctuation.terminator.semicolon.pluto`,
+        `                     -            meta.typehint.table.pluto`,
+        `                      -           variable.other.field.pluto`,
+        `                       -          punctuation.separator.colon.pluto`,
+        `                        -         meta.typehint.pluto`,
+        `                         ------   storage.type.primitive.pluto`,
+        `                               -  meta.typehint.table.pluto`,
+        `                                - punctuation.section.table.end.pluto`
     );
 
     checkClassification(
-        `local p: { x: number, y: number } = { x = 1, y = 2 }`,
-        `-----                                                storage.modifier.pluto`,
-        `     --                                              meta.typehint.table.pluto`,
-        `       -                                             punctuation.separator.colon.pluto`,
-        `        -                                            meta.typehint.table.pluto`,
-        `         -                                           punctuation.section.table.begin.pluto`,
-        `          -                                          meta.typehint.table.pluto`,
-        `           -                                         variable.other.field.pluto`,
-        `            -                                        punctuation.separator.colon.pluto`,
-        `             -                                       meta.typehint.pluto`,
-        `              ------                                 storage.type.primitive.pluto`,
-        `                    -                                punctuation.separator.comma.pluto`,
-        `                     -                               meta.typehint.table.pluto`,
-        `                      -                              variable.other.field.pluto`,
-        `                       -                             punctuation.separator.colon.pluto`,
-        `                        -                            meta.typehint.pluto`,
-        `                         ------                      storage.type.primitive.pluto`,
-        `                               -                     meta.typehint.table.pluto`,
-        `                                -                    punctuation.section.table.end.pluto`,
-        `                                  -                  keyword.operator.assignment.pluto`,
-        `                                    -                punctuation.section.table.begin.pluto`,
-        `                                     ---             meta.table.pluto`,
-        `                                        -            keyword.operator.assignment.pluto`,
-        `                                         -           meta.table.pluto`,
-        `                                          -          constant.numeric.integer.pluto`,
-        `                                           -         punctuation.separator.comma.pluto`,
-        `                                            ---      meta.table.pluto`,
-        `                                               -     keyword.operator.assignment.pluto`,
-        `                                                -    meta.table.pluto`,
-        `                                                 -   constant.numeric.integer.pluto`,
-        `                                                  -  meta.table.pluto`,
-        `                                                   - punctuation.section.table.end.pluto`
+        `local p: { x: number, y: number }`,
+        `-----                             storage.modifier.pluto`,
+        `     --                           meta.typehint.table.pluto`,
+        `       -                          punctuation.separator.colon.pluto`,
+        `        -                         meta.typehint.table.pluto`,
+        `         -                        punctuation.section.table.begin.pluto`,
+        `          -                       meta.typehint.table.pluto`,
+        `           -                      variable.other.field.pluto`,
+        `            -                     punctuation.separator.colon.pluto`,
+        `             -                    meta.typehint.pluto`,
+        `              ------              storage.type.primitive.pluto`,
+        `                    -             punctuation.separator.comma.pluto`,
+        `                     -            meta.typehint.table.pluto`,
+        `                      -           variable.other.field.pluto`,
+        `                       -          punctuation.separator.colon.pluto`,
+        `                        -         meta.typehint.pluto`,
+        `                         ------   storage.type.primitive.pluto`,
+        `                               -  meta.typehint.table.pluto`,
+        `                                - punctuation.section.table.end.pluto`
     );
 
     checkClassification(

--- a/test.js
+++ b/test.js
@@ -107,6 +107,41 @@ async function main()
     );
 
     checkClassification(
+        `local p: { x: number, y: number } = { x = 1, y = 2 }`,
+        `-----                                                storage.modifier.pluto`,
+        `     --                                              meta.typehint.table.pluto`,
+        `       -                                             punctuation.separator.colon.pluto`,
+        `        -                                            meta.typehint.table.pluto`,
+        `         -                                           punctuation.section.table.begin.pluto`,
+        `          -                                          meta.typehint.table.pluto`,
+        `           -                                         variable.other.field.pluto`,
+        `            -                                        punctuation.separator.colon.pluto`,
+        `             -                                       meta.typehint.pluto`,
+        `              ------                                 storage.type.primitive.pluto`,
+        `                    -                                punctuation.separator.comma.pluto`,
+        `                     -                               meta.typehint.table.pluto`,
+        `                      -                              variable.other.field.pluto`,
+        `                       -                             punctuation.separator.colon.pluto`,
+        `                        -                            meta.typehint.pluto`,
+        `                         ------                      storage.type.primitive.pluto`,
+        `                               -                     meta.typehint.table.pluto`,
+        `                                -                    punctuation.section.table.end.pluto`,
+        `                                  -                  keyword.operator.assignment.pluto`,
+        `                                    -                punctuation.section.table.begin.pluto`,
+        `                                     ---             meta.table.pluto`,
+        `                                        -            keyword.operator.assignment.pluto`,
+        `                                         -           meta.table.pluto`,
+        `                                          -          constant.numeric.integer.pluto`,
+        `                                           -         punctuation.separator.comma.pluto`,
+        `                                            ---      meta.table.pluto`,
+        `                                               -     keyword.operator.assignment.pluto`,
+        `                                                -    meta.table.pluto`,
+        `                                                 -   constant.numeric.integer.pluto`,
+        `                                                  -  meta.table.pluto`,
+        `                                                   - punctuation.section.table.end.pluto`
+    );
+
+    checkClassification(
         `local function f(cb: { a: string })`,
         `-----                               storage.modifier.pluto`,
         `      --------                      storage.type.function.pluto`,

--- a/test.js
+++ b/test.js
@@ -146,6 +146,29 @@ async function main()
         `                                  -          keyword.operator.assignment.pluto`
     );
 
+    checkClassification(
+        `local function f(cb: function(a: string): int)`,
+        `-----                                          storage.modifier.pluto`,
+        `      --------                                 storage.type.function.pluto`,
+        `              -                                meta.function.pluto`,
+        `               -                               entity.name.function.pluto`,
+        `                -                              punctuation.section.group.begin.pluto`,
+        `                 --                            variable.parameter.function.pluto`,
+        `                   -                           punctuation.separator.colon.pluto`,
+        `                    -                          meta.typehint.function.pluto`,
+        `                     --------                  storage.type.function.pluto`,
+        `                             -                 punctuation.section.group.begin.pluto`,
+        `                              -                variable.parameter.function.pluto`,
+        `                               -               punctuation.separator.colon.pluto`,
+        `                                -              meta.typehint.pluto`,
+        `                                 ------        storage.type.primitive.pluto`,
+        `                                       -       punctuation.section.group.end.pluto`,
+        `                                        -      punctuation.separator.colon.pluto`,
+        `                                         -     meta.typehint.pluto`,
+        `                                          ---  storage.type.primitive.pluto`,
+        `                                             - punctuation.section.group.end.pluto`
+    );
+
     const langConfig = JSON.parse(
         fs.readFileSync(path.join(__dirname, "language-config.json"), "utf8").replace(/\/\/.*$/gm, "")
     );


### PR DESCRIPTION
## Summary
- expand Pluto grammar to parse table type hints, including nested fields
- test highlighting for variables and parameters with table type hints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893413cdbbc8325ae0dcd543834ad22