### PR TITLE
feat: add $type named type syntax highlighting

### DIFF
--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -191,23 +191,59 @@
 					<string>meta.preprocessoralias.pluto</string>
 					<key>patterns</key>
 					<array>
-						<dict>
-							<key>match</key>
-							<string>[a-zA-Z_][a-zA-Z0-9_]*</string>
-							<key>name</key>
-							<string>variable.parameter.preprocessoralias.pluto</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>,</string>
-							<key>name</key>
-							<string>punctuation.separator.comma.pluto</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(function)($|\s+)(?:[a-zA-Z_][a-zA-Z0-9_]*([.:]))?([a-zA-Z_][a-zA-Z0-9_]*)?</string>
+                                               <dict>
+                                                       <key>match</key>
+                                                       <string>[a-zA-Z_][a-zA-Z0-9_]*</string>
+                                                       <key>name</key>
+                                                       <string>variable.parameter.preprocessoralias.pluto</string>
+                                               </dict>
+                                               <dict>
+                                                       <key>match</key>
+                                                       <string>,</string>
+                                                       <key>name</key>
+                                                       <string>punctuation.separator.comma.pluto</string>
+                                               </dict>
+                                       </array>
+                               </dict>
+                                <dict>
+                                        <key>begin</key>
+                                        <string>(\$type)\s+(?:[a-zA-Z_][a-zA-Z0-9_]*([.:]))?([a-zA-Z_][a-zA-Z0-9_]*)\s*(=)</string>
+                                        <key>beginCaptures</key>
+                                        <dict>
+                                                <key>1</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>storage.type.typedef.pluto</string>
+                                                </dict>
+                                                <key>2</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>punctuation.separator.parameter.pluto</string>
+                                                </dict>
+                                                <key>3</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>entity.name.type.pluto</string>
+                                                </dict>
+                                                <key>4</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>keyword.operator.assignment.pluto</string>
+                                                </dict>
+                                        </dict>
+                                        <key>end</key>
+                                        <string>$</string>
+                                        <key>patterns</key>
+                                        <array>
+                                                <dict>
+                                                        <key>include</key>
+                                                        <string>#pluto</string>
+                                                </dict>
+                                        </array>
+                                </dict>
+                                <dict>
+                                        <key>match</key>
+                                        <string>\b(function)($|\s+)(?:[a-zA-Z_][a-zA-Z0-9_]*([.:]))?([a-zA-Z_][a-zA-Z0-9_]*)?</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -482,7 +518,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\$(define|alias)\b</string>
+                                        <string>\$(define|alias|type)\b</string>
 					<key>name</key>
 					<string>storage.modifier.pluto</string>
 				</dict>

--- a/test.js
+++ b/test.js
@@ -81,6 +81,60 @@ async function main()
         `             --   storage.type.function.arrow.pluto`,
         `                - constant.numeric.integer.pluto`
     );
+    checkClassification(
+        `$type StringOrNumber = string|number`,
+        `-----                                storage.type.typedef.pluto`,
+        `      --------------                 entity.name.type.pluto`,
+        `                     -               keyword.operator.assignment.pluto`,
+        `                       ------        support.function.library.pluto`,
+        `                             -       keyword.operator.logical.pluto`
+    );
+    checkClassification(
+        `$type Point = { x: number, y: number }`,
+        `-----                                  storage.type.typedef.pluto`,
+        `      -----                            entity.name.type.pluto`,
+        `            -                          keyword.operator.assignment.pluto`,
+        `              -                        punctuation.section.table.begin.pluto`,
+        `               --                      meta.table.pluto`,
+        `                 -                     punctuation.separator.colon.pluto`,
+        `                  -------              meta.table.pluto`,
+        `                         -             punctuation.separator.comma.pluto`,
+        `                          --           meta.table.pluto`,
+        `                            -          punctuation.separator.colon.pluto`,
+        `                             --------  meta.table.pluto`,
+        `                                     - punctuation.section.table.end.pluto`
+    );
+    checkClassification(
+        `$type Point = { x: number; y: number }`,
+        `-----                                  storage.type.typedef.pluto`,
+        `      -----                            entity.name.type.pluto`,
+        `            -                          keyword.operator.assignment.pluto`,
+        `              -                        punctuation.section.table.begin.pluto`,
+        `               --                      meta.table.pluto`,
+        `                 -                     punctuation.separator.colon.pluto`,
+        `                  -------              meta.table.pluto`,
+        `                         -             punctuation.terminator.pluto`,
+        `                          --           meta.table.pluto`,
+        `                            -          punctuation.separator.colon.pluto`,
+        `                             --------  meta.table.pluto`,
+        `                                     - punctuation.section.table.end.pluto`
+    );
+    checkClassification(
+        `$type Callback = function(a: string): int`,
+        `-----                                     storage.type.typedef.pluto`,
+        `      --------                            entity.name.type.pluto`,
+        `               -                          keyword.operator.assignment.pluto`,
+        `                 --------                 storage.type.function.pluto`,
+        `                         -                punctuation.section.group.begin.pluto`,
+        `                          -               variable.parameter.function.pluto`,
+        `                           -              punctuation.separator.colon.pluto`,
+        `                            -             meta.typehint.pluto`,
+        `                             ------       storage.type.primitive.pluto`,
+        `                                   -      punctuation.section.group.end.pluto`,
+        `                                    -     punctuation.separator.colon.pluto`,
+        `                                     -    meta.function.pluto`,
+        `                                      --- storage.type.primitive.pluto`
+    );
 
     const langConfig = JSON.parse(
         fs.readFileSync(path.join(__dirname, "language-config.json"), "utf8").replace(/\/\/.*$/gm, "")


### PR DESCRIPTION
## Summary
- highlight `$type` declarations and capture named types
- extend tests for various `$type` usages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936d78017083258a6db80719c3cb80