### PR TITLE
Highlight type hints for multiple return values

### DIFF
--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -56,7 +56,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\))(?:(:)\s+(void|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??))?(\s*&lt;nodiscard&gt;)?</string>
+					<string>(\))(?:(:)\s+(void|\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??))?(\s*&lt;nodiscard&gt;)?</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -122,7 +122,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\??)</string>
+					<string>(:)\s+(\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??)</string>
 							<key>captures</key>
 							<dict>
 								<key>1</key>
@@ -625,7 +625,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\??)</string>
+					<string>(:)\s+(\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??)</string>
 							<key>captures</key>
 							<dict>
 								<key>1</key>
@@ -1428,7 +1428,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\??)</string>
+					<string>(:)\s+(\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -1521,7 +1521,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\??)</string>
+					<string>(:)\s+(\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -1572,7 +1572,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\??)</string>
+					<string>(:)\s+(\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -1648,7 +1648,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(:)\s+(\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*)\??)</string>
+					<string>(:)\s+(\([^)]*\)|\??(?:(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\|)*(?:string|number|int|float|bool(?:ean)?|function|table|userdata|any|nil|[a-zA-Z_][a-zA-Z0-9_]*|\{[^}]*\})\??)</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>

--- a/test.js
+++ b/test.js
@@ -190,6 +190,19 @@ async function main()
     );
 
     checkClassification(
+        `local function f(): (bool, int)`,
+        `-----                           storage.modifier.pluto`,
+        `      --------                  storage.type.function.pluto`,
+        `              -                 meta.function.pluto`,
+        `               -                entity.name.function.pluto`,
+        `                -               punctuation.section.group.begin.pluto`,
+        `                 -              punctuation.section.group.end.pluto`,
+        `                  -             punctuation.separator.colon.pluto`,
+        `                   -            meta.function.pluto`,
+        `                    ----------- storage.type.primitive.pluto`
+    );
+
+    checkClassification(
         `$type StringOrNumber = string|number`,
         `-----                                storage.type.named.pluto`,
         `     -                               meta.type.named.pluto`,


### PR DESCRIPTION
## Summary
- support parenthesized return type lists in grammar
- add tests for function returning multiple values

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68aa89298b748325b81df6d867fc22ae