### PR TITLE
Fix function in $type and $declare triggering indent pattern

### DIFF
--- a/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
+++ b/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
@@ -7,7 +7,7 @@
 		<dict>
 			<!-- Keep in sync with language-config.json -->
 			<key>increaseIndentPattern</key>
-			<string>(^\s*\$?\b((local)?[\s\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
+			<string>(^\s*\$?(?!declare\s+function\b)\b((local)?[\s\w=]+)?(function(?!\s*\([^)]*\)\s*:)|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
 			<key>decreaseIndentPattern</key>
 			<string>(^\s*\$?\b(elsei|elseif|else|catch|pluto_catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
 		</dict>

--- a/language-config.json
+++ b/language-config.json
@@ -5,7 +5,7 @@
 	},
 	// Keep in sync with Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
 	"indentationRules": {
-		"increaseIndentPattern": "(^\\s*\\$?\\b((local)?[\\s\\w=]+)?(function|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
+		"increaseIndentPattern": "(^\\s*\\$?(?!declare\\s+function\\b)\\b((local)?[\\s\\w=]+)?(function(?!\\s*\\([^)]*\\)\\s*:)|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
 		"decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|pluto_catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -342,6 +342,8 @@ async function main()
     checkIndentation("until finished", false, true);
     checkIndentation("values = {", true, false);
     checkIndentation("}", false, true);
+    checkIndentation("$type Func = function(_: string): void", false, false);
+    checkIndentation("$declare function tonumber(str: string, base: ?number): number", false, false);
 
     if (!ok)
     {


### PR DESCRIPTION
## Summary
- avoid triggering indentation for `function` keywords in type aliases and `declare` functions
- cover `declare function` with indentation test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8f8458c483259f9a14c20a645183