### PR TITLE
Highlight compile-time conditionals

### DIFF
--- a/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
+++ b/Pluto.tmbundle/Syntaxes/Pluto.tmLanguage
@@ -727,6 +727,12 @@
 				</dict>
 				<dict>
 					<key>match</key>
+					<string>\$(?:if|elseif|else|end)\b</string>
+					<key>name</key>
+					<string>keyword.control.pluto</string>
+				</dict>
+				<dict>
+					<key>match</key>
 					<string>\b(?&lt;![.:])(break|continue|do|else|for|if|elseif|goto|return|switch|pluto_switch|then|repeat|while|until|end|in|as|case|default|begin|pluto_use|pluto_try|pluto_catch|try|catch)\b</string>
 					<key>name</key>
 					<string>keyword.control.pluto</string>

--- a/test.js
+++ b/test.js
@@ -313,6 +313,21 @@ async function main()
         `                                                        ------ storage.type.primitive.pluto`
     );
 
+    checkClassification(
+        `$if true then`,
+        `---           keyword.control.pluto`,
+        `    ----      constant.language.pluto`,
+        `         ---- keyword.control.pluto`
+    );
+    checkClassification(
+        `$else`,
+        `----- keyword.control.pluto`
+    );
+    checkClassification(
+        `$end`,
+        `---- keyword.control.pluto`
+    );
+
     const langConfig = JSON.parse(
         fs.readFileSync(path.join(__dirname, "language-config.json"), "utf8").replace(/\/\/.*$/gm, "")
     );


### PR DESCRIPTION
## Summary
- highlight `$if`, `$elseif`, `$else`, and `$end` as control keywords
- test compile-time conditional tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa9653f40483258e24afe5c061f278