### PR TITLE
Fix indentation pattern for local entry

### DIFF
--- a/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
+++ b/Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
@@ -7,7 +7,7 @@
 		<dict>
 			<!-- Keep in sync with language-config.json -->
 			<key>increaseIndentPattern</key>
-			<string>(^\s*\$?(?!declare\s+function\b)\b((local)?[\s\w=]+)?(function(?!\s*\([^)]*\)\s*:)|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
+                        <string>(^\s*\$?(?!declare\s+function\b)\b((local)?[\s\w=]+)?\b(function(?!\s*\([^)]*\)\s*:)|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\b((?!\bend\b).)*$|^.*\b(do|then)\b((?!\bend\b).)*$|^.*\{((?!\}).)*$)</string>
 			<key>decreaseIndentPattern</key>
 			<string>(^\s*\$?\b(elsei|elseif|else|catch|pluto_catch|end|until)\b.*$|^((?!\{).)*\}\;?.*$)</string>
 		</dict>

--- a/language-config.json
+++ b/language-config.json
@@ -5,7 +5,7 @@
 	},
 	// Keep in sync with Pluto.tmbundle/Preferences/Indentation Rules.tmPreferences
 	"indentationRules": {
-		"increaseIndentPattern": "(^\\s*\\$?(?!declare\\s+function\\b)\\b((local)?[\\s\\w=]+)?(function(?!\\s*\\([^)]*\\)\\s*:)|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
+                "increaseIndentPattern": "(^\\s*\\$?(?!declare\\s+function\\b)\\b((local)?[\\s\\w=]+)?\\b(function(?!\\s*\\([^)]*\\)\\s*:)|repeat|else|elseif|if|while|class|pluto_class|enum|pluto_enum|try|pluto_try)\\b((?!\\bend\\b).)*$|^.*\\b(do|then)\\b((?!\\bend\\b).)*$|^.*\\{((?!\\}).)*$)",
 		"decreaseIndentPattern": "(^\\s*\\$?\\b(elsei|elseif|else|catch|pluto_catch|end|until)\\b.*$|^((?!\\{).)*\\}\\;?.*$)"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -362,6 +362,7 @@ async function main()
     checkIndentation("}", false, true);
     checkIndentation("$type Func = function(_: string): void", false, false);
     checkIndentation("$declare function tonumber(str: string, base: ?number): number", false, false);
+    checkIndentation("local entry", false, false);
 
     if (!ok)
     {


### PR DESCRIPTION
## Summary
- avoid increasing indentation for lines like `local entry`
- keep tmPreferences in sync with updated language-config
- test indentation rules for `local entry`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abc6437ebc8325bc3ebb2cc30dfd26